### PR TITLE
handling dependencies of the rdac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-cace/templates/xschemrc
-cace/templates/*.sym
-cace/templates/*.spice
 runs/*
 netlist/*
-xschem/xschemrc
 xschem/*.spice
 mag/*.ext
 mag/*.res.ext

--- a/cace/sky130_ef_ip__rdac3v_8bit.yaml
+++ b/cace/sky130_ef_ip__rdac3v_8bit.yaml
@@ -22,11 +22,6 @@ paths:
   layout: gds
   netlist: netlist
 
-dependencies:
-  sky130_ef_ip__samplehold:
-    path: ../
-    repository: https://github.com/RTimothyEdwards/sky130_ef_ip__samplehold
-
 pins:
   b7:0:
     description: Digital input (8 bits)

--- a/xschem/sky130_ef_ip__rdac3v_8bit.sch
+++ b/xschem/sky130_ef_ip__rdac3v_8bit.sch
@@ -491,7 +491,6 @@ C {devices/ipin.sym} -1040 -2410 0 0 {name=p14 lab=b7}
 C {devices/lab_pin.sym} -1050 -3150 0 0 {name=l39 sig_type=std_logic lab=vdd}
 C {devices/iopin.sym} -1030 -3250 0 1 {name=p15 lab=dvdd}
 C {devices/iopin.sym} -1030 -3220 0 1 {name=p16 lab=dvss}
-C {../../sky130_ef_ip__samplehold/xschem/follower_amp.sym} 1160 -2720 0 0 {name=x6}
 C {devices/lab_pin.sym} 940 -2730 0 0 {name=l2 sig_type=std_logic lab=out_unbuf}
 C {passtrans.sym} 690 -2470 0 0 {name=x15}
 C {dac_column_dummy.sym} 150 -2090 0 0 {name=x18}
@@ -499,3 +498,5 @@ C {dac_column_dummy.sym} 150 -1970 0 0 {name=x5}
 C {dac_column_dummy.sym} 150 -3000 0 0 {name=x4}
 C {dac_column_dummy.sym} 150 -3100 0 0 {name=x16}
 C {devices/lab_pin.sym} 1020 -2600 0 1 {name=p18 sig_type=std_logic lab=dvss}
+C {follower_amp.sym} 1160 -2720 0 0 {name=x6
+}

--- a/xschem/xschemrc
+++ b/xschem/xschemrc
@@ -1,0 +1,11 @@
+# Source the PDK xschemrc file
+if {![info exists PDK]} {
+    source $env(PDK_ROOT)/$env(PDK)/libs.tech/xschem/xschemrc
+}
+
+# Add current directory to xschem library path
+append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
+
+# Source the dependencies
+source [file dirname [info script]]/../dependencies/sky130_ef_ip__samplehold/xschem/xschemrc
+


### PR DESCRIPTION
block depends on the "follower amp" which comes form the "samplehold" IP. 
the "follower amp" symbol path is updated in the "rdac" sch to the "rdac/dependencies" directory. 
removed the "dependencies" entry from the yaml file. 
removed xschemrc from the gitignore list.    